### PR TITLE
Arreglando problemas con multimarcas

### DIFF
--- a/AnalisisItem/Src/Function/tablasHtml.R
+++ b/AnalisisItem/Src/Function/tablasHtml.R
@@ -233,7 +233,7 @@ reporteItem <-  function(x, idPrueba, carNR = c("O", "M"), dirBase = getwd()) {
                 "", TRIED, RIGHT, PCT, "", BISERIAL,                                                   # 16 - 21
                 'disc' = ifelse(is.na(disc), "NA", paste0(disc, " (", eedisc, ") ")),                                             # 22
                 'dif'  = ifelse(is.na(dif_NEW), "NA", ifelse(eedif_NEW != "NA", paste0(dif_NEW, " (", eedif_NEW, ") "), dif_NEW)), dir_OP, dir_ICC,                   # 23 - 25
-                'Mult' = paste0("M: ", round(M_prop * 100, 2), "% (",  round(M_mAbility, 3), ")"),     # 26
+                'Mult' = ifelse(M_prop == "No aplica", M_prop, paste0("M: ", round(M_prop * 100, 2), "% (",  round(M_mAbility, 3), ")")),     # 26
                 'Omis' = paste0("O: ", round(O_prop * 100, 2), "% (",  round(O_mAbility, 3), ")"),     # 27
                 'Chis' = ifelse(is.na(chi2), "NA", paste0(chi2, "(pval = ", p_val_chi2, ") - gl = ", gl_chi2)),                   # 28
                 FLAGA, FLAGB, FLAGBISE, FLAGCORR, FLAGINFIT, FLAGKEY1, FLAGKEY2, FLAGKEY3, FLAGMEAN,   # 29 - 37


### PR DESCRIPTION
Cuando no se encuentran multimarcas en el archivo .dat, se debe poner "No aplica".